### PR TITLE
manifests: Correcting the configuration tester options

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ Installs and configures packetbeat.
   (default: '0644')
 - `device`: [String] The name of the interface from which to capture traffic.
   (default: 'any')
+- `disable_config_test`: [Boolean] If true, disable configuration file testing. It
+   is generally recommended to leave this parameter at this default value.
+   (default: false)
 - `fields`: [Hash] Optional fields to add any additional information to the output.
   (default: undef)
 - `fields_under_root`: [Boolean] By default custom fields are under a `fields`

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,6 +1,10 @@
 class packetbeat::config {
   assert_private()
 
+  $validate_cmd      = $packetbeat::disable_config_test ? {
+    true    => undef,
+    default => "${packetbeat::path_home}/bin/packetbeat -N -configtest -c %",
+  }
   $packetbeat_config = delete_undef_values({
     'name'              => $packetbeat::beat_name,
     'fields'            => $packetbeat::fields,
@@ -52,6 +56,6 @@ class packetbeat::config {
     group        => 'root',
     mode         => $packetbeat::config_file_mode,
     content      => inline_template("### Packetbeat configuration managed by Puppet ###\n\n<%= @packetbeat_config.to_yaml() %>"),
-    validate_cmd => "${packetbeat::path_home}/bin/packetbeat -N -configtest -e %",
+    validate_cmd => $validate_cmd,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,10 @@
 # [String] The name of the interface device from which to capture the 
 # traffic. (default: 'any')
 #
+# * `disable_config_test`
+# [Boolean] If true, disable configuration file testing. It is generally
+# recommended to leave this parameter at this default value. (default: false)
+#
 # * `fields`
 # Optional[Hash] Optional fields to add additional information to the output.
 # (default: undef)
@@ -165,6 +169,7 @@ class packetbeat(
   Optional[Integer] $buffer_size_mb                                   = undef,
   String $config_file_mode                                            = '0644',
   String $device                                                      = 'any',
+  Boolean $disable_config_test                                        = false,
   Optional[Hash] $fields                                              = undef,
   Boolean $fields_under_root                                          = false,
   Boolean $flow_enable                                                = true,


### PR DESCRIPTION
Replacing '-e' with the correct '-c'
Also adding new parameter 'disable_config_test' if users opt to disable
configuration file testing. It is recommended to leave this set to false.

Resolves #1 