### PR TITLE
Removing unsupported queue_size parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,8 +191,6 @@ Installs and configures packetbeat.
   (default: /var/log/packetbeat)
 - `processors`: [Array[Hash]] Add processors to the configuration to run on data
   before sending to the output. (default: undef)
-- `queue_size`: [Integer] The queue size for single events in the processing
-  pipeline. (default: 1000)
 - `service_ensure`: [String] Determine the state of the packet beat service. Must
   be one of 'enabled', 'disabled', 'running', 'unmanaged'. (default: enabled)
 - `service_has_restart`: [Boolean] When true the Service resource issues the

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -20,7 +20,6 @@ class packetbeat::config inherits packetbeat {
       'home' => $packetbeat::path_home,
       'logs' => $packetbeat::path_logs,
     },
-    'queue_size'        => $packetbeat::queue_size,
     'tags'              => $packetbeat::tags,
     'processors'        => $packetbeat::processors,
     'packetbeat'        => {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -92,10 +92,6 @@
 # enhancing or additional decoding of data before being sent to the
 # output.
 #
-# * `queue_size`
-# [Number] The internal queue size for single events in the processing
-# pipeline. (default: 1000)
-#
 # * `service_ensure`
 # [String] The desired state of the packetbeat service. Must be one of
 # 'enabled', 'disabled', 'running' or 'unmanaged'. (default: 'enabled')
@@ -194,7 +190,6 @@ class packetbeat(
   Stdlib::Absolutepath $path_home                                     = '/usr/share/packetbeat',
   Stdlib::Absolutepath $path_logs                                     = '/var/log/packetbeat',
   Optional[Array[Hash]] $processors                                   = undef,
-  Integer $queue_size                                                 = 1000,
   Enum['enabled', 'disabled', 'running', 'unmanaged'] $service_ensure = 'enabled',
   Boolean $service_has_restart                                        = true,
   Integer $snaplen                                                    = 65535,

--- a/spec/classes/packetbeat_spec.rb
+++ b/spec/classes/packetbeat_spec.rb
@@ -238,6 +238,26 @@ describe 'packetbeat', type: 'class' do
         it { is_expected.to contain_class('packetbeat::install').that_comes_before('Class[packetbeat::config]').that_notifies('Class[packetbeat::service]') }
         it { is_expected.to contain_class('packetbeat::service') }
       end
+
+      context 'with removed parameter queue_size' do
+        let :params do
+          {
+            outputs:     {
+              'elasticsearch' => {
+                'hosts' => ['http://localhost:9200'],
+              },
+            },
+            protocols:   {
+              'icmp' => {
+                'enabled' => true,
+              },
+            },
+            queue_size:  1000,
+          }
+        end
+
+        it { is_expected.not_to compile }
+      end
     end
   end
 end


### PR DESCRIPTION
Supports #7

The queue_size and bulk_queue_size parameters have been removed in Beats
6.0.
Adding test case to ensure the removed parameter is no longer supported