### PR TITLE
Removing unsupported sniffer type 'pf_ring'

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,7 @@ Installs and configures packetbeat.
   environments can accept the default, on a physical interface the optimal value
   is the MTU size. (default: 65535)
 - `sniff_type`: [String] Configure the sniffer type, packet beat only supports
-  'pcap', 'af_packet' (Linux only, faster than 'pcap') and 'pf_ring' (Requires
-  a kernel module and a re-compilation of Packetbeat, not supported by Elastic).
-  (default: 'pcap')
+  'pcap', and 'af_packet' (Linux only, faster than 'pcap'). (default: 'pcap')
 - `tags`: [Array] Optional list of tags to help group different logical properties
   easily. (default: undef)
 - `with_vlans`: [Boolean] If traffic contains VLAN tags all traffic is offset by

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -198,7 +198,7 @@ class packetbeat(
   Enum['enabled', 'disabled', 'running', 'unmanaged'] $service_ensure = 'enabled',
   Boolean $service_has_restart                                        = true,
   Integer $snaplen                                                    = 65535,
-  Enum['pcap', 'af_packet', 'pf_ring'] $sniff_type                    = 'pcap',
+  Enum['pcap', 'af_packet'] $sniff_type                               = 'pcap',
   Optional[Array[String]] $tags                                       = undef,
   Optional[Boolean] $with_vlans                                       = undef,
 ) {

--- a/spec/classes/packetbeat_spec.rb
+++ b/spec/classes/packetbeat_spec.rb
@@ -238,6 +238,26 @@ describe 'packetbeat', type: 'class' do
         it { is_expected.to contain_class('packetbeat::install').that_comes_before('Class[packetbeat::config]').that_notifies('Class[packetbeat::service]') }
         it { is_expected.to contain_class('packetbeat::service') }
       end
+
+      context 'with sniff_type = pf_ring' do
+        let :params do
+          {
+            outputs:     {
+              'elasticsearch' => {
+                'hosts' => ['http://localhost:9200'],
+              },
+            },
+            protocols:   {
+              'icmp' => {
+                'enabled' => true,
+              },
+            },
+            sniff_type:  'pf_ring',
+          }
+        end
+
+        it { is_expected.not_to compile }
+      end
     end
   end
 end


### PR DESCRIPTION
Supports #7

This sniffer type was officially removed in 6.0 but has been unsupported
for a long time. It requires a special compiling of the Kernel and there
was no good way to test it.
Adding a test case to support this removal.