### PR TITLE
Removing all $path_* parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,14 +181,6 @@ Installs and configures packetbeat.
   to the node's package manager. (default: true)
 - `package_ensure`: [String] The desired state of the Package resources. Only
   applicable if `ensure` is 'present'. (default: 'present')
-- `path_conf`: [Stdlib::Absolutepath] The base path for all packetbeat
-  configurations. (default: /etc/packetbeat)
-- `path_data`: [Stdlib::Absolutepath] The base path to where packetbeat stores
-  its data. (default: /var/lib/packetbeat)
-- `path_home`: [Stdlib::Absolutepath] The base path for the packetbeat installation,
-  where the packetbeat binary is stored. (default: /usr/share/packetbeat)
-- `path_logs`: [Stdlib::Absolutepath] The base path for packetbeat's log files.
-  (default: /var/log/packetbeat)
 - `processors`: [Array[Hash]] Add processors to the configuration to run on data
   before sending to the output. (default: undef)
 - `queue_size`: [Integer] The queue size for single events in the processing
@@ -214,7 +206,7 @@ Installs and configures packetbeat.
 
 #### Class: `packetbeat::config`
 
-Manages packetbeats main configuration file under `path_conf`
+Manages packetbeats main configuration file.
 
 #### Class: `packetbeat::install`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,19 +7,13 @@
 class packetbeat::config inherits packetbeat {
   $validate_cmd      = $packetbeat::disable_config_test ? {
     true    => undef,
-    default => "${packetbeat::path_home}/bin/packetbeat -N -configtest -c %",
+    default => '/usr/share/packetbeat/bin/packetbeat -N -configtest -c %',
   }
   $packetbeat_config = delete_undef_values({
     'name'              => $packetbeat::beat_name,
     'fields'            => $packetbeat::fields,
     'fields_under_root' => $packetbeat::fields_under_root,
     'logging'           => $packetbeat::logging,
-    'path'              => {
-      'conf' => $packetbeat::path_conf,
-      'data' => $packetbeat::path_data,
-      'home' => $packetbeat::path_home,
-      'logs' => $packetbeat::path_logs,
-    },
     'queue_size'        => $packetbeat::queue_size,
     'tags'              => $packetbeat::tags,
     'processors'        => $packetbeat::processors,
@@ -55,11 +49,11 @@ class packetbeat::config inherits packetbeat {
 
   file{'packetbeat.yml':
     ensure       => $packetbeat::ensure,
-    path         => "${packetbeat::path_conf}/packetbeat.yml",
+    path         => '/etc/packetbeat/packetbeat.yml',
     owner        => 'root',
     group        => 'root',
     mode         => $packetbeat::config_file_mode,
-    content      => inline_template("### Packetbeat configuration managed by Puppet ###\n\n<%= @packetbeat_config.to_yaml() %>"),
+    content      => inline_template('<%= @packetbeat_config.to_yaml() %>'),
     validate_cmd => $validate_cmd,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,19 +74,6 @@
 # * `package_ensure`
 # [String] The state the packetbeat package should be in. (default: present)
 #
-# * `path_conf`
-# [Absolute Path] The location of the configuration files. This setting
-# also controls the path to `packetbeat.yml`.
-#
-# * `path_data`
-# [Absolute Path] The location of the persistent data files.
-#
-# * `path_home`
-# [Absolute Path] The home of the Packetbeat configuration.
-#
-# * `path_logs`
-# [Absolute Path] The location of the logs created by Packetbeat.
-#
 # * `processors`
 # Optional[Array[Hash]] Configure processors to perform filtering, 
 # enhancing or additional decoding of data before being sent to the
@@ -189,10 +176,6 @@ class packetbeat(
   },
   Boolean $manage_repo                                                = true,
   String $package_ensure                                              = 'present',
-  Stdlib::Absolutepath $path_conf                                     = '/etc/packetbeat',
-  Stdlib::Absolutepath $path_data                                     = '/var/lib/packetbeat',
-  Stdlib::Absolutepath $path_home                                     = '/usr/share/packetbeat',
-  Stdlib::Absolutepath $path_logs                                     = '/var/log/packetbeat',
   Optional[Array[Hash]] $processors                                   = undef,
   Integer $queue_size                                                 = 1000,
   Enum['enabled', 'disabled', 'running', 'unmanaged'] $service_ensure = 'enabled',

--- a/spec/classes/packetbeat_spec.rb
+++ b/spec/classes/packetbeat_spec.rb
@@ -238,6 +238,30 @@ describe 'packetbeat', type: 'class' do
         it { is_expected.to contain_class('packetbeat::install').that_comes_before('Class[packetbeat::config]').that_notifies('Class[packetbeat::service]') }
         it { is_expected.to contain_class('packetbeat::service') }
       end
+
+      context 'with path_conf param' do
+        let(:params) { { 'path_conf' => '/etc/packetbeat' } }
+
+        it { is_expected.to raise_error(Puppet::Error) }
+      end
+
+      context 'with path_data param' do
+        let(:params) { { 'path_data' => '/var/lib/packetbeat' } }
+
+        it { is_expected.to raise_error(Puppet::Error) }
+      end
+
+      context 'with path_home param' do
+        let(:params) { { 'path_home' => '/usr/share/packetbeat' } }
+
+        it { is_expected.to raise_error(Puppet::Error) }
+      end
+
+      context 'with path_logs param' do
+        let(:params) { { 'path_logs' => '/var/lgs/packetbeat' } }
+
+        it { is_expected.to raise_error(Puppet::Error) }
+      end
     end
   end
 end


### PR DESCRIPTION
Effective modification of these parameters also requires additional changes, particularly to the services init script or unit file. These files are outside the scope of this project and there is no plan to add them.

Resolves #11