### PR TITLE
Changing the format of CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,27 @@
-Changelog
-=========
+# Changelog
+
+All notable changes to this project will be documented in this file
 
 ## [0.1.1](https://github.com/corey-hammerton/puppet-packetbeat/tree/0.1.1)
 
-- Fixing configuration file validation
-- Adding new parameter `disable_config_test` to allow users to opt-out of syntax checking
-- Optimizing data validation of class parameters
-- Adding Puppet 5 support
+This is a bug fix release with support for Puppet 5
+
+**Added**
+- Puppet 5 support
+- Parameter `disable_config_test`, enabling users to opt-out of configuration file validation
+
+**Bug Fixes**
+- Packetbeat configuration file validation
+
+**Misc**
+- Replacing Pattern type parameters that allow specific values with Enum
 
 ## [0.1.0](https://github.com/corey-hammerton/puppet-packetbeat/tree/0.1.0)
 
-- Initial release, review [module examples](https://github.com/corey-hammerton/puppet-packetbeat/blob/0.1.0/examples/init.pp) and [packetbeat documentation](https://www.elastic.co/guide/en/beats/packetbeat/current/index.html)
-  for configuration options
+Initial release, review module and [documentation](https://www.elastic.co/guide/en/beats/packetbeat/current/index.html) for configuration options
+
+**Added**
+
+**Bug Fixes**
+
+**Misc**


### PR DESCRIPTION
The new format is more consistent with the metricbeat project. This also allows more flexible modification to this file. For example, contributers will now be able to edit changelog entries in their PRs instead of the project maintainer upon release time.