### PR TITLE
Facter and sniff_type patches

### DIFF
--- a/lib/facter/packetbeat_version.rb
+++ b/lib/facter/packetbeat_version.rb
@@ -7,6 +7,6 @@ Facter.add('packetbeat_version') do
       '/usr/share/packetbeat/bin/packetbeat -version',
     )
 
-    %r{^packetbeat version ([0-9.]+)}.match(packetbeat_version)[1]
+    %r{^packetbeat version ([0-9.]+)}.match(packetbeat_version)[1] unless packetbeat_version.nil?
   end
 end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,7 +10,7 @@ class packetbeat::config inherits packetbeat {
     default => '/usr/share/packetbeat/bin/packetbeat -N -configtest -c %',
   }
   if $packetbeat::major_version == '5' {
-    $packetbeat_config = delete_undef_values({
+    $packetbeat_config_base = delete_undef_values({
       'name'              => $packetbeat::beat_name,
       'fields'            => $packetbeat::fields,
       'fields_under_root' => $packetbeat::fields_under_root,
@@ -35,7 +35,7 @@ class packetbeat::config inherits packetbeat {
     })
   }
   else {
-    $packetbeat_config = delete_undef_values({
+    $packetbeat_config_base = delete_undef_values({
       'name'              => $packetbeat::beat_name,
       'fields'            => $packetbeat::fields,
       'fields_under_root' => $packetbeat::fields_under_root,
@@ -71,7 +71,10 @@ class packetbeat::config inherits packetbeat {
       },
     })
 
-    $packetbeat_config = merge($packetbeat_config, $af_packet_config)
+    $packetbeat_config = deep_merge($packetbeat_config_base, $af_packet_config)
+  }
+  else {
+    $packetbeat_config = $packetbeat_config_base
   }
 
   file{'packetbeat.yml':


### PR DESCRIPTION
While using the module I encountered a couple of problems:
- the facter threw an error about the version when packetbeat was not installed 
- it was not possible to set the parameter sniff_type to af_packet, the code tried to re-define a variable.