### PR TITLE
Fix: Run apt update before package installation

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -24,6 +24,10 @@ class packetbeat::repo inherits packetbeat {
             source => 'https://artifacts.elastic.co/GPG-KEY-elasticsearch',
           },
         }
+
+        if $packetbeat::ensure == 'present' {
+          Class['apt::update'] -> Package['packetbeat']
+        }
       }
     }
     'Redhat': {

--- a/spec/classes/packetbeat_spec.rb
+++ b/spec/classes/packetbeat_spec.rb
@@ -96,6 +96,7 @@ describe 'packetbeat', type: 'class' do
           end
         when 'Debian'
           it { is_expected.to contain_class('apt') }
+          it { is_expected.to contain_class('apt::update').that_comes_before('Package[packetbeat]') }
 
           it do
             is_expected.to contain_apt__source('beats').with(


### PR DESCRIPTION
Hello

This commit fixes an ordering violation.
Specifically, executing apt update must precede package installation.

This is the error I get, when Puppet tries to install the package before invoking `apt-update`.

```
Notice: /Stage[main]/Packetbeat::Repo/Apt::Source[beats]/Apt::Setting[list-beats]/File[/etc/apt/sources.list.d/beats.list]/ensure: defined content as '{md5}ddca0756f7c9899c13799b2f55dd0aee'
Error: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install packetbeat' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package packetbeat
Error: /Stage[main]/Packetbeat::Install/Package[packetbeat]/ensure: change from purged to present failed: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install packetbeat' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package packetbeat
```

More details in the official documentation of puppetlabs-apt:
https://github.com/puppetlabs/puppetlabs-apt#adding-new-sources-or-ppas

> If you are adding a new source and trying to install packagesfrom the new source on the same Puppet run, your package resourceshould depend on Class[’apt::update’], as well as depending on theApt::Source resource”